### PR TITLE
Updated the manual download links to the latest ML release

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -22,8 +22,8 @@
 
 > It's **highly** recommended to use the automated installation when you can.
 
-1. - If your game is 32bit download [MelonLoader.x86.zip](https://github.com/LavaGang/MelonLoader/releases/download/v0.5.0/MelonLoader.x86.zip)
-   - If your game is 64bit download [MelonLoader.x64.zip](https://github.com/LavaGang/MelonLoader/releases/download/v0.5.0/MelonLoader.x64.zip)
+1. - If your game is 32bit download [MelonLoader.x86.zip](https://github.com/LavaGang/MelonLoader/releases/latest/download/MelonLoader.x86.zip)
+   - If your game is 64bit download [MelonLoader.x64.zip](https://github.com/LavaGang/MelonLoader/releases/latest/download/MelonLoader.x64.zip)
 2. Extract the MelonLoader folder from the zip file you just downloaded to the Game's Installation Folder.
 3. Extract version.dll as well from the zip file you just downloaded to the Game's Installation Folder. 
 


### PR DESCRIPTION
The current branch has invalid links to the old 0.5.0 version, so I decided to make the links always redirect the user to the latest version so this issue doesn't occur again