### PR TITLE
Added: HarmonyX Developer to Credits

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -31,3 +31,4 @@ Here is the list of persons that have helped in any way to the creation of Melon
 ### Outsiders
 - Perfare: Developer of Il2CppDumper
 - pardeike: Developer of Harmony
+- ghorsington: Developer of HarmonyX (fork)


### PR DESCRIPTION
MelonLoader uses HarmonyX fork (and its features) as opposed to vanilla Harmony, specifically for patching native il2cpp methods in the backend via a custom `MethodPatcher`, might be a good idea to credit the HarmonyX fork developer too.

