### PR TITLE
Remove BoneTome from Jobsimulator.md

### DIFF
--- a/docs/games/jobsimulator.md
+++ b/docs/games/jobsimulator.md
@@ -1,3 +1,3 @@
 # Job Simulator
 
-> The majority of Job Simulator modding can be found in the [Job Simulator Modding Discord Server](https://discord.gg/SF4ZyjE7pc) as well as mods can be found on [The BoneTome](https://bonetome.com/jobsimulator/)
+> The majority of Job Simulator modding can be found in the [Job Simulator Modding Discord Server](https://discord.gg/SF4ZyjE7pc)


### PR DESCRIPTION
BoneTome domain now has a `bouncy.php` page setup, typically associated with Badware.

uBlock warning:
![firefox_kop3qmzq8u](https://github.com/LavaGang/MelonWiki/assets/13679909/6e42726b-8340-45fe-963a-1a0c6df691cc)
