### PR TITLE
Remove Job Simulator

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,7 +7,6 @@
     - [BTD6](games/btd6.md)
     - [Demeo](games/demeo.md)
     - [H3VR](games/h3vr.md)
-    - [Job Simulator](games/jobsimulator.md)
     - [Pistol Whip](games/pistolwhip.md)
     - [The Long Dark](games/tld.md)
 - <span class=rootfolder>Developing Melons</span>

--- a/docs/games/jobsimulator.md
+++ b/docs/games/jobsimulator.md
@@ -1,3 +1,0 @@
-# Job Simulator
-
-> The majority of Job Simulator modding can be found in the [Job Simulator Modding Discord Server](https://discord.gg/SF4ZyjE7pc)


### PR DESCRIPTION
The community was dead since it began and has no purpose being on the wiki anymore.